### PR TITLE
Fix Storybook 10 compatibility

### DIFF
--- a/src/Panel/Content/Hints/get-dom-path.ts
+++ b/src/Panel/Content/Hints/get-dom-path.ts
@@ -39,7 +39,7 @@ const getDomPath = (element: Element) => {
         element = element.parentNode as Element;
     }
 
-    const toFilter = ['html', 'body', 'div#root'];
+    const toFilter = ['html', 'body', 'div#storybook-root'];
 
     return stack
         .filter((stackElement) => !toFilter.includes(stackElement))

--- a/src/Panel/Content/Hints/utils.ts
+++ b/src/Panel/Content/Hints/utils.ts
@@ -13,8 +13,13 @@ import type {
     Warnings,
 } from './types';
 
-const getElements = (container: HTMLElementWithStyleSheets, tag: string) =>
-    Array.from(container.querySelectorAll(tag));
+const getElements = (container: HTMLElementWithStyleSheets, tag: string) => {
+    const root = container.querySelector('#storybook-root');
+
+    return Array.from(container.querySelectorAll(tag)).filter(
+        (e) => !root || root.contains(e),
+    );
+};
 
 const getStylesheetRules = (
     sheets: Record<string, CSSStyleSheet>,
@@ -275,22 +280,23 @@ function* getSrcsetWarnings(container: HTMLElementWithStyleSheets) {
 
 function* getBackgroundImageWarnings(container: HTMLElementWithStyleSheets) {
     const backgroundImageRegex = /url\(".*?(.png|.jpg|.jpeg)"\)/;
-    const elsWithBackgroundImage = getElements(container, '#root *').filter(
-        (element) => {
-            const style = getComputedStyle(element);
-            // @ts-ignore
-            const backgroundImageStyle = style['background-image'];
+    const elsWithBackgroundImage = getElements(
+        container,
+        '#storybook-root *',
+    ).filter((element) => {
+        const style = getComputedStyle(element);
+        // @ts-ignore
+        const backgroundImageStyle = style['background-image'];
 
-            return (
-                backgroundImageStyle &&
-                backgroundImageRegex.test(backgroundImageStyle) &&
-                // HACK
-                // ideally, we would make a new image element and check its "naturalWidth"
-                // to get a better idea of the size of the background image, this is a hack
-                element.clientWidth > 200
-            );
-        },
-    );
+        return (
+            backgroundImageStyle &&
+            backgroundImageRegex.test(backgroundImageStyle) &&
+            // HACK
+            // ideally, we would make a new image element and check its "naturalWidth"
+            // to get a better idea of the size of the background image, this is a hack
+            element.clientWidth > 200
+        );
+    });
 
     if (elsWithBackgroundImage.length === 0) return [];
 
@@ -443,7 +449,7 @@ export const getOriginalStyles = (
 };
 
 function* get100vhWarnings(container: HTMLElementWithStyleSheets) {
-    const elements = getElements(container, '#root *');
+    const elements = getElements(container, '#storybook-root *');
     const {length} = elements;
     const result = [];
 


### PR DESCRIPTION
The element id of the preview root element was changed, and the preview iframe can now contain internal Storybook elements that fail the scan, so we restrict the scan to the actual preview root.